### PR TITLE
change authentication key to username,session input field

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,6 @@ class User < ApplicationRecord
   has_many :questions
   has_many :experiences, through: :user_experiences
   validates :username, presence: true, uniqueness: true, format: { with: /\A[a-zA-Z0-9]{6,20}\z/ }
-  validates :password, presence: true, length: { minimum: 8 }
+  validates :password, presence: true, length: { minimum: 6 }
   validates :email, presence: true, format: { with: /[a-zA-z0-9._]{3,}@\w{3,}\.\w{2,}/ }
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,10 +2,10 @@
 
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="form-inputs">
-    <%= f.input :email,
+    <%= f.input :username,
                 required: false,
                 autofocus: true,
-                input_html: { autocomplete: "email" } %>
+                input_html: { autocomplete: "username" } %>
     <%= f.input :password,
                 required: false,
                 input_html: { autocomplete: "current-password" } %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:username]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the


### PR DESCRIPTION
## Why

This pull request is needed because:

Change authentication key to username(log in via username instead of email)


## What

This pull request introduces the following:

- change sessions#new form email input field to username
- change config.authentication_keys from [:email] to [:username]

