### PR TITLE
fix gambly link, fix location filter dropdown

### DIFF
--- a/app/views/experiences/index.html.erb
+++ b/app/views/experiences/index.html.erb
@@ -26,10 +26,10 @@
       Filter by Location
     </button>
     <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-      <%= link_to "North", filter_by_location_experiences_path, class: "dropdown-item" %>
-      <%= link_to "South", filter_by_location_experiences_path, class: "dropdown-item" %>
-      <%= link_to "East", filter_by_location_experiences_path, class: "dropdown-item" %>
-      <%= link_to "West", filter_by_location_experiences_path, class: "dropdown-item" %>
+      <%= link_to "North", experiences_path, class: "dropdown-item" %>
+      <%= link_to "South", experiences_path, class: "dropdown-item" %>
+      <%= link_to "East", experiences_path, class: "dropdown-item" %>
+      <%= link_to "West", experiences_path, class: "dropdown-item" %>
     </div>
   </div>
 </div>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -37,7 +37,7 @@
 
       <div class="btn-wrapper row px-3">
         <div class="text-center col-6 btn-border">
-            <%= link_to "Take a Gambly", experiences_path %>
+            <%= link_to "Take a Gambly", sample_experiences_path %>
         </div>
 
         <div class="text-center col-6 btn-border">


### PR DESCRIPTION
## Why

This pull request is needed because:

There were bugs with gambly link routing to index page and location filter links

[Link to Card]()

## What

This pull request introduces the following:

 * Gambly link now routes to sample page
 * Location filter links do not break website anymore (still no route)
